### PR TITLE
Optimize active check

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,19 +33,15 @@ if ($bbPMCheckReady instanceof bbPMCheckReady) {
 
     // load plugin
     require('BbpMessages.php');
+
+    // init
+    global $bbpm_loader;
+    // loader class
+    $bbpm_loader = new \BBP_MESSAGES\BbpMessages;
+    // setup
+    $bbpm_loader->setup();
 }
 
-
-/**
-  * Init plugin when bbPress is active
-  */
-global $bbpm_loader;
-// loader class
-$bbpm_loader = new \BBP_MESSAGES\BbpMessages;
-// setup
-$bbpm_loader->setup();
-
-// init
 function bbp_messages_loaded(){
     global $bbpm_loader;
 

--- a/index.php
+++ b/index.php
@@ -46,7 +46,7 @@ function bbp_messages_loaded(){
     global $bbpm_loader;
 
     if( ! class_exists('bbPress') ) {
-        return add_action('admin_init', array($bbpm_loader, 'deactivate'));;
+        return add_action('admin_init', array($bbpm_loader, 'deactivate'));
     }
 
     $bbpm_loader->init();


### PR DESCRIPTION
- Move setting up up the loader inside the Namespace check
Because calling it outside the PHP 5.3 check could still result in a
failing website
- Fix double `;;`



