### PR TITLE
Remove duplicated label in integrate.php

### DIFF
--- a/Inc/Core/integrate.php
+++ b/Inc/Core/integrate.php
@@ -42,8 +42,6 @@ function bbpm_bbp_profile_edit_preferences_field() {
 
     ?>
     <div class="bbpm-notify">
-        <label for="bbpm_notify"></label>
-            
         <label for="bbpm_notify">
             <input type="checkbox" name="bbpm_notify" id="bbpm_notify" <?php checked(get_user_meta($user_id, 'bbpm_mute_notifications', true), false); ?> />
             <span style="vertical-align:top"><?php _e('Allow email notifications of new messages', 'bbp-messages'); ?></span>


### PR DESCRIPTION
In the file `bbp-messages/Inc/Core/integrate.php` on line 45, the `bbpm_notify' label is in the template twice.